### PR TITLE
fix: NextNet with mask length lower than current one

### DIFF
--- a/net4.go
+++ b/net4.go
@@ -209,7 +209,12 @@ func (n Net4) NextIP(ip net.IP) (net.IP, error) {
 // NextNet takes a CIDR mask-size as an argument and attempts to create a new
 // Net object just after the current Net, at the requested mask length
 func (n Net4) NextNet(masklen int) Net4 {
-	return NewNet4(NextIP(n.BroadcastAddress()), masklen)
+	l, _ := n.Mask().Size()
+	nextIP := NextIP(n.BroadcastAddress())
+	if masklen < l {
+		nextIP = IncrementIP4By(nextIP, uint32(math.Pow(2, 32-float64(masklen)))-2)
+	}
+	return NewNet4(nextIP, masklen)
 }
 
 // PreviousIP takes a net.IP as an argument and attempts to decrement it by

--- a/net4_test.go
+++ b/net4_test.go
@@ -389,9 +389,11 @@ var incr4SubnetTests = []struct {
 	netmask  int
 	next     Net4
 }{
+	{Net4FromStr("192.168.0.0/24"), 21, Net4FromStr("192.168.8.0/21")},
+	{Net4FromStr("192.168.0.0/24"), 22, Net4FromStr("192.168.4.0/22")},
+	{Net4FromStr("192.168.0.0/24"), 23, Net4FromStr("192.168.2.0/23")},
 	{Net4FromStr("192.168.0.0/24"), 24, Net4FromStr("192.168.1.0/24")},
 	{Net4FromStr("192.168.0.0/24"), 25, Net4FromStr("192.168.1.0/25")},
-	{Net4FromStr("192.168.0.0/24"), 23, Net4FromStr("192.168.0.0/23")},
 	{Net4FromStr("255.255.255.0/24"), 24, Net4FromStr("255.255.255.0/24")},
 }
 


### PR DESCRIPTION
Fixes: #12 

Without these changes, `NextNet` returns an overlapping subnet if the requested mask length is smaller than the current one.