### PR TITLE
avoid index out of bounds in IP4ToARPA function

### DIFF
--- a/iplib.go
+++ b/iplib.go
@@ -298,6 +298,9 @@ func IPToARPA(ip net.IP) string {
 // the IPv4 ARPA domain "in-addr.arpa"
 func IP4ToARPA(ip net.IP) string {
 	ip = ForceIP4(ip)
+	if ip == nil {
+		return ""
+	}
 	return fmt.Sprintf("%d.%d.%d.%d.in-addr.arpa", ip[3], ip[2], ip[1], ip[0])
 }
 


### PR DESCRIPTION
hello~

I found that in the IP4ToARPA function, when the input ip is not a valid ip, after executing the ForceIP4 function, the ip will become nil, so that when the ip index is sought, an error will be reported directly.

```
func IP4ToARPA(ip net.IP) string {
	ip = ForceIP4(ip)// ip will be nil
	return fmt.Sprintf("%d.%d.%d.%d.in-addr.arpa", ip[3], ip[2], ip[1], ip[0])
	// At this point, indexing will trigger panic
}
```

```
❯ go run main.go
panic: runtime error: index out of range [3] with length 0

goroutine 1 [running]:
github.com/c-robinson/iplib.IP4ToARPA({0x0?, 0x10276e5c0?, 0x60?})
        /Users/*/go/pkg/mod/github.com/c-robinson/iplib@v1.0.6/iplib.go:301 +0xc4
main.main()
        /Users/*/Downloads/go-fuzz-corpus-master/zlib/main.go:12 +0x2c
exit status 2
```

I try to return an empty string in advance, because it seems that invalid ip does not generate DNS PTR records~