### PR TITLE
V2 uint128

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,7 +173,7 @@ fmt.Println(n.Supernet(0))        // 192.168.0.0/15 <nil>
 
 ## Using iplib.Net6
 
-`Net6` represents and IPv6 network. In some ways v6 is simpler than v4, as
+`Net6` represents an IPv6 network. In some ways v6 is simpler than v4, as
 it does away with the special behavior of addresses at the front and back of
 the netblock. For IPv6 the primary problem is the sheer size of the thing:
 there are 2^128th addresses in IPv6, which translates to 340 undecillion!

--- a/README.md
+++ b/README.md
@@ -1,8 +1,28 @@
-# IPLib 
+# IPLib
 [![Documentation](https://godoc.org/github.com/c-robinson/iplib?status.svg)](http://godoc.org/github.com/c-robinson/iplib)
 [![CircleCI](https://circleci.com/gh/c-robinson/iplib/tree/main.svg?style=svg)](https://circleci.com/gh/c-robinson/iplib/tree/main)
 [![Go Report Card](https://goreportcard.com/badge/github.com/c-robinson/iplib)](https://goreportcard.com/report/github.com/c-robinson/iplib)
 [![Coverage Status](https://coveralls.io/repos/github/c-robinson/iplib/badge.svg?branch=main)](https://coveralls.io/github/c-robinson/iplib?branch=main)
+
+**ATTENTION** version 2.0.0 is a breaking change from previous versions for
+handling IPv6 addresses (functions for IPv4 are unchanged). Calls that result
+in arithmatic operations against IPv6 now use [uint128.Uint128](https://lukechampine.com/uint128)
+instead of `*big.Int`. Until now this library restricted itself to using the
+standard library, but `math/big` is sloooooooooow and the performance gains
+from switching were too large to ignore:
+
+| Benchmark | *big.Int | uint128.Uint128 |
+| --- | --- |-----------------|
+| Benchmark_DeltaIP6 | 79.27 ns/op | 2.809 ns/op     |
+| BenchmarkDecrementIP6By | 50.54 ns/op | 13.88 ns/op     |
+| BenchmarkIncrementIP6By | 50.48 ns/op | 13.92 ns/op     |
+| BenchmarkNet_Count6 | 122.2 ns/op | 11.26 ns/op     |
+
+It would be fantastic to remove this external dependency in some future v3
+that switched to a native `uint128` but for that to happen [this proposal](https://github.com/golang/go/issues/9455)
+(or something similar) would need to be adopted.
+
+**Okay you can stop paying attention now** 
 
 I really enjoy Python's [ipaddress](https://docs.python.org/3/library/ipaddress.html)
 library and Ruby's [ipaddr](https://ruby-doc.org/stdlib-2.5.1/libdoc/ipaddr/rdoc/IPAddr.html),
@@ -114,7 +134,8 @@ func main() {
 Addresses that require or return a count default to using `uint32`, which is
 sufficient for working with the entire IPv4 space. As a rule these functions
 are just lowest-common wrappers around IPv4- or IPv6-specific functions. The
-IPv6-specific variants use `big.Int` so they can access the entire v6 space.
+IPv6-specific variants use `uint128.Uint128` so they can access the entire v6
+space.
 
 ## The iplib.Net interface
 

--- a/example_test.go
+++ b/example_test.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"math/big"
 	"net"
+
+	"lukechampine.com/uint128"
 )
 
 func ExampleBigintToIP6() {
@@ -30,7 +32,7 @@ func ExampleDecrementIP4By() {
 }
 
 func ExampleDecrementIP6By() {
-	z := big.NewInt(16777215)
+	z := uint128.New(16777215, 0)
 	ip := net.ParseIP("2001:db8::ffff:ffff")
 	fmt.Println(DecrementIP6By(ip, z))
 	// Output: 2001:db8::ff00:0
@@ -38,8 +40,8 @@ func ExampleDecrementIP6By() {
 
 func ExampleDecrementIP6WithinHostmask() {
 	ip := net.ParseIP("2001:db8:1000::")
-	ip1, _ := DecrementIP6WithinHostmask(ip, NewHostMask(0), big.NewInt(1))
-	ip2, _ := DecrementIP6WithinHostmask(ip, NewHostMask(56), big.NewInt(1))
+	ip1, _ := DecrementIP6WithinHostmask(ip, NewHostMask(0), uint128.New(1, 0))
+	ip2, _ := DecrementIP6WithinHostmask(ip, NewHostMask(56), uint128.New(1, 0))
 	fmt.Println(ip1)
 	fmt.Println(ip2)
 	// Output:
@@ -94,7 +96,7 @@ func ExampleIncrementIP4By() {
 }
 
 func ExampleIncrementIP6By() {
-	z := big.NewInt(16777215)
+	z := uint128.New(16777215, 0)
 	ip := net.ParseIP("2001:db8::ff00:0")
 	fmt.Println(IncrementIP6By(ip, z))
 	// Output: 2001:db8::ffff:ffff
@@ -102,13 +104,18 @@ func ExampleIncrementIP6By() {
 
 func ExampleIncrementIP6WithinHostmask() {
 	ip := net.ParseIP("2001:db8:1000::")
-	ip1, _ := IncrementIP6WithinHostmask(ip, NewHostMask(0), big.NewInt(1))
-	ip2, _ := IncrementIP6WithinHostmask(ip, NewHostMask(56), big.NewInt(1))
+	ip1, _ := IncrementIP6WithinHostmask(ip, NewHostMask(0), uint128.New(1, 0))
+	ip2, _ := IncrementIP6WithinHostmask(ip, NewHostMask(56), uint128.New(1, 0))
 	fmt.Println(ip1)
 	fmt.Println(ip2)
 	// Output:
 	// 2001:db8:1000::1
 	// 2001:db8:1000:0:100::
+}
+
+func ExampleIPToBigint() {
+	fmt.Println(IPToBigint(net.ParseIP("2001:db8:85a3::8a2e:370:7334")))
+	// Output: 42540766452641154071740215577757643572
 }
 
 func ExampleIP4ToARPA() {
@@ -124,6 +131,11 @@ func ExampleIP6ToARPA() {
 func ExampleIP4ToUint32() {
 	fmt.Println(IP4ToUint32(net.ParseIP("192.168.1.1")))
 	// Output: 3232235777
+}
+
+func ExampleIP6ToUint128() {
+	fmt.Println(IP6ToUint128(net.ParseIP("2001:db8:85a3::8a2e:370:7334")))
+	// Output: 42540766452641154071740215577757643572
 }
 
 func ExampleIPToBinaryString() {
@@ -171,6 +183,12 @@ func ExamplePreviousIP6WithinHostmask() {
 func ExampleUint32ToIP4() {
 	fmt.Println(Uint32ToIP4(3232235777))
 	// Output: 192.168.1.1
+}
+
+func ExampleUint128ToIP6() {
+	z, _ := uint128.FromString("42540766452641154071740215577757643572")
+	fmt.Println(Uint128ToIP6(z))
+	// Output: 2001:db8:85a3::8a2e:370:7334
 }
 
 func ExampleVersion() {

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,5 @@
 module github.com/c-robinson/iplib
 
 go 1.12
+
+require lukechampine.com/uint128 v1.3.0 // indirect

--- a/hostmask.go
+++ b/hostmask.go
@@ -2,8 +2,9 @@ package iplib
 
 import (
 	"encoding/hex"
-	"math/big"
 	"net"
+
+	"lukechampine.com/uint128"
 )
 
 // HostMask is a mask that can be applied to IPv6 addresses to mask out bits
@@ -127,31 +128,30 @@ func (m HostMask) String() string {
 // portion of the supplied net.IP by the supplied integer value. If the
 // input or output value fall outside the boundaries of the hostmask a
 // ErrAddressOutOfRange will be returned
-func DecrementIP6WithinHostmask(ip net.IP, hm HostMask, count *big.Int) (net.IP, error) {
-	xcount := new(big.Int) // do not manipulate 'count'
-	xcount.Set(count)
-
+func DecrementIP6WithinHostmask(ip net.IP, hm HostMask, count uint128.Uint128) (net.IP, error) {
 	bb, bbpos := hm.BoundaryByte()
 	if bbpos == 0 {
 		return net.IP{}, ErrBadMaskLength
 	}
 
 	if bbpos == -1 {
-		return DecrementIP6By(ip, xcount), nil
+		return DecrementIP6By(ip, count), nil
 	}
 
 	// check if ip is outside of hostmask already
-	for _, b := range ip[bbpos+1:] {
-		if b > 0 {
+	if bbpos < 15 {
+		for _, b := range ip[bbpos+1:] {
+			if b > 0 {
+				return net.IP{}, ErrAddressOutOfRange
+			}
+		}
+		if ip[bbpos]+bb < bb {
 			return net.IP{}, ErrAddressOutOfRange
 		}
 	}
-	if ip[bbpos]+bb < bb {
-		return net.IP{}, ErrAddressOutOfRange
-	}
 
-	bb = decrementBoundaryByte(bb, ip[bbpos], xcount)
-	xip := decrementUnmaskedBytes(ip[:bbpos], xcount)
+	count, bb = decrementBoundaryByte(bb, ip[bbpos], count)
+	xip := decrementUnmaskedBytes(ip[:bbpos], count)
 	if len(xip) == 0 {
 		return xip, ErrAddressOutOfRange
 	}
@@ -171,16 +171,14 @@ func DecrementIP6WithinHostmask(ip net.IP, hm HostMask, count *big.Int) (net.IP,
 // unmasked portion of the supplied net.IP by the supplied integer value. If
 // the input or output value fall outside the boundaries of the hostmask a
 // ErrAddressOutOfRange will be returned
-func IncrementIP6WithinHostmask(ip net.IP, hm HostMask, count *big.Int) (net.IP, error) {
-	xcount := getCloneBigInt(count)
-
+func IncrementIP6WithinHostmask(ip net.IP, hm HostMask, count uint128.Uint128) (net.IP, error) {
 	bb, bbpos := hm.BoundaryByte()
 	if bbpos == 0 {
 		return net.IP{}, ErrBadMaskLength
 	}
 
 	if bbpos == -1 {
-		return IncrementIP6By(ip, xcount), nil
+		return IncrementIP6By(ip, count), nil
 	}
 
 	// check if ip is outside of hostmask already
@@ -190,8 +188,8 @@ func IncrementIP6WithinHostmask(ip net.IP, hm HostMask, count *big.Int) (net.IP,
 		}
 	}
 
-	bb = incrementBoundaryByte(bb, ip[bbpos], xcount)
-	xip := incrementUnmaskedBytes(ip[:bbpos], xcount)
+	count, bb = incrementBoundaryByte(bb, ip[bbpos], count)
+	xip := incrementUnmaskedBytes(ip[:bbpos], count)
 
 	if len(xip) > bbpos {
 		return net.IP{}, ErrAddressOutOfRange
@@ -200,7 +198,9 @@ func IncrementIP6WithinHostmask(ip net.IP, hm HostMask, count *big.Int) (net.IP,
 	xip = append(xip, bb)
 
 	xip = append(xip, make([]byte, 15-bbpos)...)
-
+	if CompareIPs(xip, ip) < 0 {
+		return net.IP{}, ErrAddressOutOfRange
+	}
 	return xip, nil
 }
 
@@ -266,43 +266,63 @@ func PreviousIP6WithinHostmask(ip net.IP, hm HostMask) (net.IP, error) {
 // decrementBoundaryByte takes a boundary-byte, a boundary-value and a count
 // as input and returns a modified boundary byte and count for further
 // processing. bb is used to calculate the maximum value for bv and then the
-// count + bv is divided by that max. The function will return the modulus
-// as a byte value, and the pointer to count will have the quotient
-func decrementBoundaryByte(bb, bv byte, count *big.Int) byte {
-	bmax := 256 - int(bb) // max value of unmasked byte as int
-	if v := count.Cmp(big.NewInt(0)); v <= 0 {
-		return bv
+// count + bv is divided by that max. The function returns a new count and
+// boundary-byte
+func decrementBoundaryByte(bb, bv byte, count uint128.Uint128) (uint128.Uint128, byte) {
+	if count.IsZero() {
+		return count, bv
 	}
-	bigbmax := big.NewInt(int64(bmax))
-	bigmod := new(big.Int)
 
-	count.DivMod(count, bigbmax, bigmod)
-	mod64 := bigmod.Int64()
-	mod := byte(mod64)
-	if mod > bv {
-		count.Add(count, big.NewInt(1))
-		return (byte(bmax) + bv) - mod
+	byteMax := uint128.From64(256 - uint64(bb)) // max value of unmasked bits in the byte
+	byteVal := uint128.From64(uint64(bv))       // cur value of unmasked bits in the byte
+
+	mod := uint128.New(0, 0)
+
+	count, mod = count.QuoRem(byteMax)
+
+	// extract the actual modulus into bmod
+	rb := make([]byte, 16)
+	mod.PutBytesBE(rb)
+	bmod := rb[15]
+
+	if bmod > bv {
+		count = count.Add64(1)
+
+		byteVal = byteVal.Add(byteMax)
+		byteVal = byteVal.Sub(mod)
+
+		// convert to byte
+		byteVal.PutBytesBE(rb)
+
+		return count, rb[15]
 	}
-	return bv - mod
+	return count, bv - bmod
 }
 
 // decrementUnmaskedBytes decrements an arbitrary []byte by count and returns
 // a []byte of the same length
-func decrementUnmaskedBytes(nb []byte, count *big.Int) []byte {
-	z := new(big.Int)
-	z.SetBytes(nb)
-	z.Sub(z, count)
+func decrementUnmaskedBytes(nb []byte, count uint128.Uint128) []byte {
+	if count.IsZero() {
+		return nb
 
-	if v := z.Sign(); v < 0 {
+	}
+
+	// convert the []byte to a uint128, which requires a [16]byte
+	pnb := append(make([]byte, 16-len(nb)), nb...)
+	n := uint128.FromBytesBE(pnb)
+
+	if count.Cmp(n) > 0 {
 		return []byte{}
 	}
 
-	zb := z.Bytes()
-	if len(zb) < len(nb) {
-		zb = append(make([]byte, len(nb)-len(zb)), zb...)
-	}
+	n = n.Sub(count)
 
-	return zb
+	// convert the uint128 back to a []byte
+	xb := make([]byte, 16)
+	n.PutBytesBE(xb)
+
+	// return only as many elements as were passed in
+	return xb[16-len(nb):]
 }
 
 // incrementBoundaryByte takes a boundary-byte, a boundary-value and a count
@@ -310,47 +330,42 @@ func decrementUnmaskedBytes(nb []byte, count *big.Int) []byte {
 // processing. bb is used to calculate the maximum value for bv and then the
 // count + bv is divided by that max. The function will return the modulus
 // as a byte value, and the pointer to count will have the quotient
-func incrementBoundaryByte(bb, bv byte, count *big.Int) byte {
-	if v := count.Cmp(big.NewInt(0)); v <= 0 {
-		return bv
+func incrementBoundaryByte(bb, bv byte, count uint128.Uint128) (uint128.Uint128, byte) {
+	if count.IsZero() {
+		return count, bv
+	}
+	byteMax := uint128.From64(256 - uint64(bb)) // max value of unmasked bits in the byte
+	byteVal := uint128.From64(uint64(bv))       // cur value of unmasked bits in the byte
+
+	count = count.Add(byteVal)
+	if count.Cmp(byteMax) < 0 {
+		return uint128.Uint128{}, byte(count.Lo)
 	}
 
-	bigbmax := big.NewInt(256 - int64(bb)) // max value of unmasked byte as an int
-	bigbval := big.NewInt(int64(bv))       // cur value of unmasked byte as an int
-
-	count.Add(count, bigbval)
-
-	// if count is less than bmax, we're done
-	if v := count.Cmp(bigbmax); v < 0 {
-		b := count.Bytes()
-		count.Set(big.NewInt(0))
-		if len(b) == 0 {
-			return 0
-		}
-		return b[0]
-	}
-
-	bigmod := new(big.Int)
-
-	count.DivMod(count, bigbmax, bigmod)
-	mod := bigmod.Bytes()
-	if len(mod) == 0 {
-		return byte(0)
-	}
-	return mod[0]
+	mod := uint128.New(0, 0)
+	count, mod = count.QuoRem(byteMax)
+	rb := make([]byte, 16)
+	mod.PutBytesBE(rb)
+	return count, rb[15]
 }
 
 // incrementUnmaskedBytes increments an arbitrary []byte by count and returns
 // a []byte of the same length
-func incrementUnmaskedBytes(nb []byte, count *big.Int) []byte {
-	z := new(big.Int)
-	z.SetBytes(nb)
-	z.Add(z, count)
-
-	zb := z.Bytes()
-	if len(zb) < len(nb) {
-		zb = append(make([]byte, len(nb)-len(zb)), zb...)
+func incrementUnmaskedBytes(nb []byte, count uint128.Uint128) []byte {
+	if count.IsZero() {
+		return nb
 	}
 
-	return zb
+	// convert the []byte to a uint128, which requires a [16]byte
+	pnb := append(make([]byte, 16-len(nb)), nb...)
+	n := uint128.FromBytesBE(pnb)
+
+	n = n.Add(count)
+
+	// convert the uint128 back to a []byte
+	xb := make([]byte, 16)
+	n.PutBytesBE(xb)
+
+	// return only as many elements as were passed in
+	return xb[16-len(nb):]
 }

--- a/iplib.go
+++ b/iplib.go
@@ -463,10 +463,7 @@ func IsAllZeroes(ip net.IP) bool {
 	return true
 }
 
-// NextIP returns a net.IP incremented by one from the input address. This
-// function is roughly as fast for v4 as IncrementIP4By(1) but is consistently
-// 4x faster on v6 than IncrementIP6By(1). The bundled tests provide
-// benchmarks doing so, as well as iterating over the entire v4 address space.
+// NextIP returns a net.IP incremented by one from the input address
 func NextIP(ip net.IP) net.IP {
 	var xip []byte
 	if EffectiveVersion(ip) == IP4Version {
@@ -484,10 +481,7 @@ func NextIP(ip net.IP) net.IP {
 	return ip // if we're already at the end of range, don't wrap
 }
 
-// PreviousIP returns a net.IP decremented by one from the input address. This
-// function is roughly as fast for v4 as DecrementIP4By(1) but is consistently
-// 4x faster on v6 than DecrementIP6By(1). The bundled tests provide
-// benchmarks doing so, as well as iterating over the entire v4 address space.
+// PreviousIP returns a net.IP decremented by one from the input address
 func PreviousIP(ip net.IP) net.IP {
 	var xip []byte
 	if EffectiveVersion(ip) == IP4Version {

--- a/iplib.go
+++ b/iplib.go
@@ -305,6 +305,9 @@ func IPToARPA(ip net.IP) string {
 // the IPv4 ARPA domain "in-addr.arpa"
 func IP4ToARPA(ip net.IP) string {
 	ip = ForceIP4(ip)
+	if ip == nil {
+		return ""
+	}
 	return fmt.Sprintf("%d.%d.%d.%d.in-addr.arpa", ip[3], ip[2], ip[1], ip[0])
 }
 

--- a/iplib_bench_test.go
+++ b/iplib_bench_test.go
@@ -165,9 +165,12 @@ func BenchmarkNet_Subnet_v6(b *testing.B) {
 		_, _ = n6.Subnet(99, 0)
 	}
 <<<<<<< HEAD
+<<<<<<< HEAD
 =======
 
 >>>>>>> 8809338 (Change from *big.Int to uint128.Uint128)
+=======
+>>>>>>> 64c8610 (add subnet_v6 benchmark)
 }
 
 func BenchmarkNet_PreviousNet_v4(b *testing.B) {

--- a/iplib_bench_test.go
+++ b/iplib_bench_test.go
@@ -1,9 +1,10 @@
 package iplib
 
 import (
-	"math/big"
 	"net"
 	"testing"
+
+	"lukechampine.com/uint128"
 )
 
 func BenchmarkParseCIDR4(b *testing.B) {
@@ -71,7 +72,7 @@ func BenchmarkPreviousIP6(b *testing.B) {
 
 func BenchmarkDecrementIP6By(b *testing.B) {
 	var xip = net.IP{32, 1, 13, 184, 133, 163, 0, 0, 0, 0, 138, 46, 3, 112, 115, 52}
-	count := big.NewInt(1)
+	count := uint128.From64(1)
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		xip = DecrementIP6By(xip, count)
@@ -115,7 +116,7 @@ func BenchmarkNextIP6(b *testing.B) {
 
 func BenchmarkIncrementIP6By(b *testing.B) {
 	var xip = net.IP{32, 1, 13, 184, 133, 163, 0, 0, 0, 0, 138, 46, 3, 112, 115, 52}
-	count := big.NewInt(1)
+	count := uint128.From64(1)
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		xip = IncrementIP6By(xip, count)
@@ -153,15 +154,6 @@ func BenchmarkNet_Subnet_v4(b *testing.B) {
 	b.StartTimer()
 	for i := 0; i < b.N; i++ {
 		_, _ = n4.Subnet(25)
-	}
-}
-
-func BenchmarkNet_Subnet_v6(b *testing.B) {
-	_, n, _ := ParseCIDR("2001:db8::/98")
-	n4 := n.(Net4)
-	b.StartTimer()
-	for i := 0; i < b.N; i++ {
-		_, _ = n4.Subnet(99)
 	}
 }
 
@@ -217,7 +209,26 @@ func BenchmarkNewNetBetween_v6(b *testing.B) {
 	}
 }
 
-func BenchmarkNet6_nextIPWithinHostmask(b *testing.B) {
+func BenchmarkNet6_PreviousIPWithinHostmask(b *testing.B) {
+	var xip = net.IP{32, 1, 13, 184, 133, 163, 0, 0, 0, 0, 138, 46, 3, 112, 115, 52}
+	hm := NewHostMask(8)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		xip, _ = PreviousIP6WithinHostmask(xip, hm)
+	}
+}
+
+func BenchmarkNet6_DecrementIP6WithinHostmask(b *testing.B) {
+	var xip = net.IP{32, 1, 13, 184, 133, 163, 0, 0, 0, 0, 138, 46, 3, 112, 115, 52}
+	count := uint128.From64(1)
+	hm := NewHostMask(8)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		xip, _ = DecrementIP6WithinHostmask(xip, hm, count)
+	}
+}
+
+func BenchmarkNet6_NextIPWithinHostmask(b *testing.B) {
 	var xip = net.IP{32, 1, 13, 184, 133, 163, 0, 0, 0, 0, 138, 46, 3, 112, 115, 52}
 	hm := NewHostMask(8)
 	b.ResetTimer()
@@ -226,9 +237,9 @@ func BenchmarkNet6_nextIPWithinHostmask(b *testing.B) {
 	}
 }
 
-func BenchmarkNet6_incrementIP6WithinHostmask(b *testing.B) {
+func BenchmarkNet6_IncrementIP6WithinHostmask(b *testing.B) {
 	var xip = net.IP{32, 1, 13, 184, 133, 163, 0, 0, 0, 0, 138, 46, 3, 112, 115, 52}
-	count := big.NewInt(1)
+	count := uint128.From64(1)
 	hm := NewHostMask(8)
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {

--- a/iplib_bench_test.go
+++ b/iplib_bench_test.go
@@ -164,6 +164,10 @@ func BenchmarkNet_Subnet_v6(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		_, _ = n6.Subnet(99, 0)
 	}
+<<<<<<< HEAD
+=======
+
+>>>>>>> 8809338 (Change from *big.Int to uint128.Uint128)
 }
 
 func BenchmarkNet_PreviousNet_v4(b *testing.B) {
@@ -254,4 +258,17 @@ func BenchmarkNet6_NextIPWithinHostmask(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		xip, _ = NextIP6WithinHostmask(xip, hm)
 	}
+<<<<<<< HEAD
+=======
+}
+
+func BenchmarkNet6_IncrementIP6WithinHostmask(b *testing.B) {
+	var xip = net.IP{32, 1, 13, 184, 133, 163, 0, 0, 0, 0, 138, 46, 3, 112, 115, 52}
+	count := uint128.From64(1)
+	hm := NewHostMask(8)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		xip, _ = IncrementIP6WithinHostmask(xip, hm, count)
+	}
+>>>>>>> 8809338 (Change from *big.Int to uint128.Uint128)
 }

--- a/iplib_bench_test.go
+++ b/iplib_bench_test.go
@@ -218,6 +218,16 @@ func BenchmarkNewNetBetween_v6(b *testing.B) {
 	}
 }
 
+func BenchmarkNet6_DecrementIP6WithinHostmask(b *testing.B) {
+	var xip = net.IP{32, 1, 13, 184, 133, 163, 0, 0, 0, 0, 138, 46, 3, 112, 115, 52}
+	count := uint128.From64(1)
+	hm := NewHostMask(8)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		xip, _ = DecrementIP6WithinHostmask(xip, hm, count)
+	}
+}
+
 func BenchmarkNet6_PreviousIPWithinHostmask(b *testing.B) {
 	var xip = net.IP{32, 1, 13, 184, 133, 163, 0, 0, 0, 0, 138, 46, 3, 112, 115, 52}
 	hm := NewHostMask(8)
@@ -227,7 +237,7 @@ func BenchmarkNet6_PreviousIPWithinHostmask(b *testing.B) {
 	}
 }
 
-func BenchmarkNet6_DecrementIP6WithinHostmask(b *testing.B) {
+func BenchmarkNet6_IncrementIP6WithinHostmask(b *testing.B) {
 	var xip = net.IP{32, 1, 13, 184, 133, 163, 0, 0, 0, 0, 138, 46, 3, 112, 115, 52}
 	count := uint128.From64(1)
 	hm := NewHostMask(8)
@@ -243,15 +253,5 @@ func BenchmarkNet6_NextIPWithinHostmask(b *testing.B) {
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		xip, _ = NextIP6WithinHostmask(xip, hm)
-	}
-}
-
-func BenchmarkNet6_IncrementIP6WithinHostmask(b *testing.B) {
-	var xip = net.IP{32, 1, 13, 184, 133, 163, 0, 0, 0, 0, 138, 46, 3, 112, 115, 52}
-	count := uint128.From64(1)
-	hm := NewHostMask(8)
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
-		xip, _ = IncrementIP6WithinHostmask(xip, hm, count)
 	}
 }

--- a/iplib_bench_test.go
+++ b/iplib_bench_test.go
@@ -157,6 +157,15 @@ func BenchmarkNet_Subnet_v4(b *testing.B) {
 	}
 }
 
+func BenchmarkNet_Subnet_v6(b *testing.B) {
+	_, n, _ := ParseCIDR("2001:db8::/98")
+	n6 := n.(Net6)
+	b.StartTimer()
+	for i := 0; i < b.N; i++ {
+		_, _ = n6.Subnet(99, 0)
+	}
+}
+
 func BenchmarkNet_PreviousNet_v4(b *testing.B) {
 	_, n, _ := ParseCIDR("192.168.0.0/24")
 	n4 := n.(Net4)

--- a/iplib_test.go
+++ b/iplib_test.go
@@ -6,6 +6,8 @@ import (
 	"reflect"
 	"sort"
 	"testing"
+
+	"lukechampine.com/uint128"
 )
 
 func TestCopyIP(t *testing.T) {
@@ -286,6 +288,15 @@ func TestBigintToIP6(t *testing.T) {
 	}
 }
 
+func TestIP6ToUint128(t *testing.T) {
+	for i, tt := range IP6Tests {
+		z := IP6ToUint128(net.ParseIP(tt.ipaddr))
+		if z.String() != tt.bigintval {
+			t.Errorf("[%d] want %s got %s", i, tt.bigintval, z.String())
+		}
+	}
+}
+
 func TestExpandIP6(t *testing.T) {
 	for i, tt := range IP6Tests {
 		s := ExpandIP6(net.ParseIP(tt.ipaddr))
@@ -445,9 +456,8 @@ func TestDeltaIP6(t *testing.T) {
 
 func TestDecrementIP6By(t *testing.T) {
 	for i, tt := range IPDelta6Tests {
-		z := big.Int{}
-		z.SetString(tt.intval, 10)
-		ip := DecrementIP6By(tt.ipaddr, &z)
+		z, _ := uint128.FromString(tt.intval)
+		ip := DecrementIP6By(tt.ipaddr, z)
 		x := CompareIPs(ip, tt.decr)
 		if x != 0 {
 			t.Errorf("[%d] want %s got %s", i, tt.decr, ip)
@@ -457,9 +467,8 @@ func TestDecrementIP6By(t *testing.T) {
 
 func TestIncrementIP6By(t *testing.T) {
 	for i, tt := range IPDelta6Tests {
-		z := big.Int{}
-		z.SetString(tt.intval, 10)
-		ip := IncrementIP6By(tt.ipaddr, &z)
+		z, _ := uint128.FromString(tt.intval)
+		ip := IncrementIP6By(tt.ipaddr, z)
 		x := CompareIPs(ip, tt.incr)
 		if x != 0 {
 			t.Errorf("[%d] want %s got %s", i, tt.incr, ip)

--- a/net4.go
+++ b/net4.go
@@ -252,8 +252,7 @@ func (n Net4) PreviousNet(masklen int) Net4 {
 	return NewNet4(PreviousIP(n.IP()), masklen)
 }
 
-// RandomIP returns a random address from this Net4. It uses crypto/rand and
-// *big.Int so is not the most performant implementation possible
+// RandomIP returns a random address from this Net4
 func (n Net4) RandomIP() net.IP {
 	z, _ := rand.Int(rand.Reader, big.NewInt(int64(n.Count())))
 	return IncrementIP4By(n.IP(), uint32(z.Uint64()))
@@ -335,8 +334,8 @@ func (n Net4) finalAddress() (net.IP, int) {
 
 	// apply wildcard to network, byte by byte
 	wc := n.Wildcard()
-	for pos, b := range []byte(n.IP()) {
-		xip[pos] = b + wc[pos]
+	for pos := range n.IP() {
+		xip[pos] = n.IP()[pos] + wc[pos]
 	}
 	return xip, ones
 }

--- a/net6_test.go
+++ b/net6_test.go
@@ -1,10 +1,11 @@
 package iplib
 
 import (
-	"math/big"
 	"net"
 	"sort"
 	"testing"
+
+	"lukechampine.com/uint128"
 )
 
 var NewNet6Tests = []struct {
@@ -74,7 +75,7 @@ var Net6Tests = []struct {
 	hostmask    int
 	hostmaskpos int
 	netmasklen  int
-	count       string // converted to big.Int
+	count       string // converted to uint128.Uint128
 }{
 	// 0-7 hostmask applied on byte boundaries
 	{
@@ -235,8 +236,7 @@ func TestNet6_Version(t *testing.T) {
 func TestNet6_Count(t *testing.T) {
 	for i, tt := range Net6Tests {
 		ipn := NewNet6(net.ParseIP(tt.ip), tt.netmasklen, tt.hostmask)
-		ttcount := new(big.Int)
-		ttcount.SetString(tt.count, 10)
+		ttcount, _ := uint128.FromString(tt.count)
 
 		if ipn.IPNet.IP == nil {
 			if tt.count != "0" {


### PR DESCRIPTION
Convert IPv6 functions from `*big.Int` to `uint128.Uint128`

This has resulted in an enormous performance improvement for v6 address manipulation at the cost of a breaking change to function signatures. IPv4 functions are unaffected by this change. New conversion functions have been created for Uint128. The conversion functions for `*big` are still present.